### PR TITLE
Remove criterion exclude attribute, use logical criterion combination with not instead

### DIFF
--- a/execution_engine/converter/action/abstract.py
+++ b/execution_engine/converter/action/abstract.py
@@ -143,7 +143,7 @@ class AbstractAction(CriterionConverter, metaclass=AbstractPrivateMethods):
         raise NotImplementedError()
 
     @final
-    def to_criterion(self) -> Criterion | LogicalCriterionCombination:
+    def to_positive_criterion(self) -> Criterion | LogicalCriterionCombination:
         """
         Converts this action to a criterion.
         """
@@ -156,19 +156,20 @@ class AbstractAction(CriterionConverter, metaclass=AbstractPrivateMethods):
 
         if self.goals:
             combination = LogicalCriterionCombination(
-                exclude=self._exclude,  # need to pull up the exclude flag from the criterion into the combination
+                exclude=False,
                 category=CohortCategory.INTERVENTION,
                 operator=LogicalCriterionCombination.Operator("AND"),
             )
             if action is not None:
-                action.exclude = False  # reset the exclude flag, as it is now part of the combination
+                # action.exclude = False  # reset the exclude flag, as it is now part of the combination
                 combination.add(action)
 
             for goal in self.goals:
-                combination.add(goal.to_criterion())
+                combination.add(goal.to_positive_criterion())
 
             return combination
-
+        if action is not None:
+            assert not action.exclude
         return action  # type: ignore
 
     @property

--- a/execution_engine/converter/action/abstract.py
+++ b/execution_engine/converter/action/abstract.py
@@ -155,22 +155,14 @@ class AbstractAction(CriterionConverter, metaclass=AbstractPrivateMethods):
             ), "Action without explicit criterion must have at least one goal"
 
         if self.goals:
-            combination = LogicalCriterionCombination(
-                exclude=False,
-                category=CohortCategory.INTERVENTION,
-                operator=LogicalCriterionCombination.Operator("AND"),
-            )
+            criteria = [goal.to_criterion() for goal in self.goals]
             if action is not None:
-                # action.exclude = False  # reset the exclude flag, as it is now part of the combination
-                combination.add(action)
-
-            for goal in self.goals:
-                combination.add(goal.to_positive_criterion())
-
-            return combination
-        if action is not None:
-            assert not action.exclude
-        return action  # type: ignore
+                criteria.append(action)
+            return LogicalCriterionCombination.And(
+                *criteria, category=CohortCategory.INTERVENTION
+            )
+        else:
+            return action  # type: ignore
 
     @property
     def goals(self) -> list[Goal]:

--- a/execution_engine/converter/action/assessment.py
+++ b/execution_engine/converter/action/assessment.py
@@ -19,7 +19,7 @@ from execution_engine.util.types import Timing
 
 class AssessmentAction(AbstractAction):
     """
-    An AsessmentAction is an action that is used to assess a patient's condition.
+    An AssessmentAction is an action that is used to assess a patient's condition.
 
     This action just tests whether the assessment has been performed by determining whether any value
     is present in the respective OMOP CDM table.

--- a/execution_engine/converter/action/assessment.py
+++ b/execution_engine/converter/action/assessment.py
@@ -79,7 +79,6 @@ class AssessmentAction(AbstractAction):
                 )
 
         criterion = cls(
-            exclude=self._exclude,
             category=CohortCategory.INTERVENTION,
             concept=self._code,
             timing=self._timing,

--- a/execution_engine/converter/action/body_positioning.py
+++ b/execution_engine/converter/action/body_positioning.py
@@ -53,7 +53,6 @@ class BodyPositioningAction(AbstractAction):
         """Converts this characteristic to a Criterion."""
 
         return ProcedureOccurrence(
-            exclude=False,
             category=CohortCategory.INTERVENTION,
             concept=self._code,
             timing=self._timing,

--- a/execution_engine/converter/action/body_positioning.py
+++ b/execution_engine/converter/action/body_positioning.py
@@ -53,7 +53,7 @@ class BodyPositioningAction(AbstractAction):
         """Converts this characteristic to a Criterion."""
 
         return ProcedureOccurrence(
-            exclude=self._exclude,
+            exclude=False,
             category=CohortCategory.INTERVENTION,
             concept=self._code,
             timing=self._timing,

--- a/execution_engine/converter/action/drug_administration.py
+++ b/execution_engine/converter/action/drug_administration.py
@@ -284,7 +284,7 @@ class DrugAdministrationAction(AbstractAction):
         if not self._dosages:
             # no dosages, just return the drug exposure
             return DrugExposure(
-                exclude=self._exclude,
+                exclude=False,
                 category=CohortCategory.INTERVENTION,
                 ingredient_concept=self._ingredient_concept,
                 dose=None,
@@ -316,7 +316,7 @@ class DrugAdministrationAction(AbstractAction):
                         f"Extension type {extension['type']} not supported yet"
                     )
 
-                drug_action.exclude = False  # reset the exclude flag, as it is now part of the combination
+                # drug_action.exclude = False  # reset the exclude flag, as it is now part of the combination
 
                 ext_criterion = PointInTimeCriterion(
                     exclude=False,  # extensions are always included (at least for now)
@@ -326,7 +326,7 @@ class DrugAdministrationAction(AbstractAction):
                 )
 
                 comb = NonCommutativeLogicalCriterionCombination.ConditionalFilter(
-                    exclude=drug_action.exclude,  # need to pull up the exclude flag from the criterion into the combination
+                    exclude=False,  # drug_action.exclude,  # need to pull up the exclude flag from the criterion into the combination
                     category=CohortCategory.INTERVENTION,
                     left=ext_criterion,
                     right=drug_action,
@@ -336,11 +336,12 @@ class DrugAdministrationAction(AbstractAction):
 
         if len(drug_actions) == 1:
             # set the exclude flag to the value of the action, as this is the only action
-            drug_actions[0].exclude = self._exclude
+            # drug_actions[0].exclude = self._exclude
+            assert not drug_actions[0].exclude
             return drug_actions[0]
         else:
             comb = LogicalCriterionCombination(
-                exclude=self._exclude,
+                exclude=False,  # self._exclude,
                 category=CohortCategory.INTERVENTION,
                 operator=LogicalCriterionCombination.Operator("OR"),
             )

--- a/execution_engine/converter/action/drug_administration.py
+++ b/execution_engine/converter/action/drug_administration.py
@@ -321,6 +321,10 @@ class DrugAdministrationAction(AbstractAction):
                     value=extension["value"],
                 )
 
+                # A Conditional Filter returns `right` iff left is POSITIVE, otherwise it returns NEGATIVE
+                # rational: "conditional" extensions are some conditions for dosage, such as body weight ranges.
+                # Thus, the actual drug administration (drug_action, "right") must only be fulfilled if the
+                # condition (ext_criterion, "left") is fulfilled. Thus, we here add this conditional filter.
                 comb = NonCommutativeLogicalCriterionCombination.ConditionalFilter(
                     category=CohortCategory.INTERVENTION,
                     left=ext_criterion,

--- a/execution_engine/converter/characteristic/abstract.py
+++ b/execution_engine/converter/characteristic/abstract.py
@@ -97,6 +97,6 @@ class AbstractCharacteristic(CriterionConverter, ABC):
         return standard_vocabulary.get_concept(cc.system, cc.code, standard=standard)
 
     @abstractmethod
-    def to_criterion(self) -> Criterion:
+    def to_positive_criterion(self) -> Criterion:
         """Converts this characteristic to a Criterion."""
         raise NotImplementedError()

--- a/execution_engine/converter/characteristic/abstract.py
+++ b/execution_engine/converter/characteristic/abstract.py
@@ -98,5 +98,10 @@ class AbstractCharacteristic(CriterionConverter, ABC):
 
     @abstractmethod
     def to_positive_criterion(self) -> Criterion:
-        """Converts this characteristic to a Criterion."""
+        """
+        Converts this characteristic to a "Positive" Criterion.
+
+        Positive criterion means that a possible excluded flag is disregarded. Instead, the exclusion
+        is later introduced (in the to_criterion() method) via a LogicalCriterionCombination.Not).
+        """
         raise NotImplementedError()

--- a/execution_engine/converter/characteristic/codeable_concept.py
+++ b/execution_engine/converter/characteristic/codeable_concept.py
@@ -82,7 +82,6 @@ class AbstractCodeableConceptCharacteristic(AbstractCharacteristic):
     def to_positive_criterion(self) -> Criterion:
         """Converts this characteristic to a Criterion."""
         return self._criterion_class(
-            exclude=False,
             category=CohortCategory.POPULATION,
             concept=self.value,
             value=None,

--- a/execution_engine/converter/characteristic/codeable_concept.py
+++ b/execution_engine/converter/characteristic/codeable_concept.py
@@ -79,10 +79,10 @@ class AbstractCodeableConceptCharacteristic(AbstractCharacteristic):
 
         return c
 
-    def to_criterion(self) -> Criterion:
+    def to_positive_criterion(self) -> Criterion:
         """Converts this characteristic to a Criterion."""
         return self._criterion_class(
-            exclude=self._exclude,
+            exclude=False,
             category=CohortCategory.POPULATION,
             concept=self.value,
             value=None,

--- a/execution_engine/converter/characteristic/value.py
+++ b/execution_engine/converter/characteristic/value.py
@@ -36,7 +36,6 @@ class AbstractValueCharacteristic(AbstractCharacteristic, ABC):
     def to_positive_criterion(self) -> ConceptCriterion:
         """Converts this characteristic to a Criterion."""
         return self._criterion_class(
-            exclude=False,
             category=CohortCategory.POPULATION,
             concept=self.type,
             value=self.value,

--- a/execution_engine/converter/characteristic/value.py
+++ b/execution_engine/converter/characteristic/value.py
@@ -33,10 +33,10 @@ class AbstractValueCharacteristic(AbstractCharacteristic, ABC):
 
         return c
 
-    def to_criterion(self) -> ConceptCriterion:
+    def to_positive_criterion(self) -> ConceptCriterion:
         """Converts this characteristic to a Criterion."""
         return self._criterion_class(
-            exclude=self._exclude,
+            exclude=False,
             category=CohortCategory.POPULATION,
             concept=self.type,
             value=self.value,

--- a/execution_engine/converter/converter.py
+++ b/execution_engine/converter/converter.py
@@ -112,7 +112,9 @@ class CriterionConverter(ABC):
     """
 
     def __init__(self, exclude: bool):
-        # todo: is exclude still required?
+        # The _exclude attribute is used in converter classes but gets
+        # turned into a LogicalCriterionCombination with operator NOT
+        # in the to_criterion method.
         self._exclude = exclude
 
     @classmethod
@@ -142,7 +144,6 @@ class CriterionConverter(ABC):
         in a LogicalCriterionCombination with operator NOT.
         """
         positive_criterion = self.to_positive_criterion()
-        assert positive_criterion._exclude is False
         if self._exclude:
             return LogicalCriterionCombination.Not(
                 positive_criterion, positive_criterion.category

--- a/execution_engine/converter/converter.py
+++ b/execution_engine/converter/converter.py
@@ -130,9 +130,25 @@ class CriterionConverter(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def to_criterion(self) -> Criterion | LogicalCriterionCombination:
-        """Converts this characteristic to a Criterion."""
+    def to_positive_criterion(self) -> Criterion | LogicalCriterionCombination:
+        """Converts this characteristic to a Criterion or a combination of criteria but no negation."""
         raise NotImplementedError()
+
+    def to_criterion(self) -> Criterion | LogicalCriterionCombination:
+        """
+        Converts this characteristic to a Criterion or a
+        combination of criteria. The result may be a "negative"
+        criterion, that is the result of to_positive_criterion wrapped
+        in a LogicalCriterionCombination with operator NOT.
+        """
+        positive_criterion = self.to_positive_criterion()
+        assert positive_criterion._exclude is False
+        if self._exclude:
+            return LogicalCriterionCombination.Not(
+                positive_criterion, positive_criterion.category
+            )
+        else:
+            return positive_criterion
 
 
 class CriterionConverterFactory:

--- a/execution_engine/converter/goal/assessment_scale.py
+++ b/execution_engine/converter/goal/assessment_scale.py
@@ -52,7 +52,6 @@ class AssessmentScaleGoal(Goal):
         Converts the goal to a criterion.
         """
         return Measurement(
-            exclude=False,
             category=CohortCategory.INTERVENTION,
             concept=self._code,
             value=self._value,

--- a/execution_engine/converter/goal/assessment_scale.py
+++ b/execution_engine/converter/goal/assessment_scale.py
@@ -47,12 +47,12 @@ class AssessmentScaleGoal(Goal):
 
         return cls(code.concept_name, exclude=False, code=code, value=value)
 
-    def to_criterion(self) -> Criterion:
+    def to_positive_criterion(self) -> Criterion:
         """
         Converts the goal to a criterion.
         """
         return Measurement(
-            exclude=self._exclude,
+            exclude=False,
             category=CohortCategory.INTERVENTION,
             concept=self._code,
             value=self._value,

--- a/execution_engine/converter/goal/laboratory_value.py
+++ b/execution_engine/converter/goal/laboratory_value.py
@@ -46,12 +46,12 @@ class LaboratoryValueGoal(Goal):
 
         return cls(exclude=False, code=code, value=value)
 
-    def to_criterion(self) -> Criterion:
+    def to_positive_criterion(self) -> Criterion:
         """
         Converts the goal to a criterion.
         """
         return Measurement(
-            exclude=self._exclude,
+            exclude=False,
             category=CohortCategory.INTERVENTION,
             concept=self._code,
             value=self._value,

--- a/execution_engine/converter/goal/laboratory_value.py
+++ b/execution_engine/converter/goal/laboratory_value.py
@@ -51,7 +51,6 @@ class LaboratoryValueGoal(Goal):
         Converts the goal to a criterion.
         """
         return Measurement(
-            exclude=False,
             category=CohortCategory.INTERVENTION,
             concept=self._code,
             value=self._value,

--- a/execution_engine/converter/goal/ventilator_management.py
+++ b/execution_engine/converter/goal/ventilator_management.py
@@ -66,14 +66,12 @@ class VentilatorManagementGoal(Goal):
         if self._code in CUSTOM_GOALS:
             cls = CUSTOM_GOALS[self._code]
             return cls(
-                exclude=False,
                 category=CohortCategory.INTERVENTION,
                 concept=self._code,
                 value=self._value,
             )
 
         return Measurement(
-            exclude=False,
             category=CohortCategory.INTERVENTION,
             concept=self._code,
             value=self._value,

--- a/execution_engine/converter/goal/ventilator_management.py
+++ b/execution_engine/converter/goal/ventilator_management.py
@@ -59,7 +59,7 @@ class VentilatorManagementGoal(Goal):
 
         return cls(exclude=False, code=code, value=value)
 
-    def to_criterion(self) -> Criterion:
+    def to_positive_criterion(self) -> Criterion:
         """
         Converts the goal to a criterion.
         """
@@ -73,7 +73,7 @@ class VentilatorManagementGoal(Goal):
             )
 
         return Measurement(
-            exclude=self._exclude,
+            exclude=False,
             category=CohortCategory.INTERVENTION,
             concept=self._code,
             value=self._value,

--- a/execution_engine/converter/parser/fhir_parser_v1.py
+++ b/execution_engine/converter/parser/fhir_parser_v1.py
@@ -176,6 +176,5 @@ class FhirRecommendationParserV1(FhirRecommendationParserInterface):
             )
         return LogicalCriterionCombination(
             category=CohortCategory.INTERVENTION,
-            exclude=False,
             operator=operator,
         )

--- a/execution_engine/converter/parser/fhir_parser_v2.py
+++ b/execution_engine/converter/parser/fhir_parser_v2.py
@@ -66,6 +66,5 @@ class FhirRecommendationParserV2(FhirRecommendationParserV1):
 
         return LogicalCriterionCombination(
             category=CohortCategory.INTERVENTION,
-            exclude=False,
             operator=operator,
         )

--- a/execution_engine/execution_graph/graph.py
+++ b/execution_engine/execution_graph/graph.py
@@ -506,25 +506,11 @@ class ExecutionGraph(nx.DiGraph):
                 if isinstance(entry, CriterionCombination):
                     components.append(_traverse(entry))
                 elif isinstance(entry, Criterion):
-                    # Remove the exclude criterion from the symbol, as it is handled by the Not operator
-                    s = logic.Symbol(
-                        entry
-                        # criterion=cast(Criterion, entry.clear_exclude(inplace=False))
-                    )
-
-                    # if entry.exclude:
-                    #    s = logic.Not(s, category=entry.category)
-                    assert not entry._exclude
-                    components.append(s)
+                    components.append(logic.Symbol(entry))
                 else:
                     raise ValueError(f"Invalid entry type: {type(entry)}")
 
-            c = conjunction(*components, category=comb.category)
-
-            if comb.exclude:
-                c = logic.Not(c, category=comb.category)
-
-            return c
+            return conjunction(*components, category=comb.category)
 
         expression = _traverse(comb)
 

--- a/execution_engine/execution_graph/graph.py
+++ b/execution_engine/execution_graph/graph.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Type, cast
+from typing import Any, Callable, Type
 
 import networkx as nx
 
@@ -369,7 +369,7 @@ class ExecutionGraph(nx.DiGraph):
             comb: CriterionCombination,
         ) -> Type[logic.BooleanFunction] | Callable:
             """
-            Convert the criterion's operator into a logical conjunction (And or Or)
+            Convert the criterion's operator into a logical conjunction (Not or And or Or)
             """
             if isinstance(comb, LogicalCriterionCombination):
                 if comb.is_root():
@@ -388,6 +388,8 @@ class ExecutionGraph(nx.DiGraph):
                     return logic.NonSimplifiableAnd
                 elif isinstance(comb, NonCommutativeLogicalCriterionCombination):
                     return logic.ConditionalFilter
+                elif comb.operator.operator == LogicalCriterionCombination.Operator.NOT:
+                    return logic.Not
                 elif comb.operator.operator == LogicalCriterionCombination.Operator.AND:
                     return logic.And
                 elif comb.operator.operator == LogicalCriterionCombination.Operator.OR:
@@ -506,12 +508,13 @@ class ExecutionGraph(nx.DiGraph):
                 elif isinstance(entry, Criterion):
                     # Remove the exclude criterion from the symbol, as it is handled by the Not operator
                     s = logic.Symbol(
-                        criterion=cast(Criterion, entry.clear_exclude(inplace=False))
+                        entry
+                        # criterion=cast(Criterion, entry.clear_exclude(inplace=False))
                     )
 
-                    if entry.exclude:
-                        s = logic.Not(s, category=entry.category)
-
+                    # if entry.exclude:
+                    #    s = logic.Not(s, category=entry.category)
+                    assert not entry._exclude
                     components.append(s)
                 else:
                     raise ValueError(f"Invalid entry type: {type(entry)}")

--- a/execution_engine/fhir_omop_mapping.py
+++ b/execution_engine/fhir_omop_mapping.py
@@ -38,14 +38,17 @@ def characteristic_to_criterion(
         )
         comb = LogicalCriterionCombination(
             category=CohortCategory.POPULATION,
-            exclude=characteristic.exclude,
+            exclude=False,
             operator=operator,
         )
         for c in characteristic:
             comb.add(characteristic_to_criterion(c))
-        return comb
+        if characteristic.exclude:
+            return LogicalCriterionCombination.Not(comb, CohortCategory.POPULATION)
+        else:
+            return comb
     else:
-        return characteristic.to_criterion()
+        return characteristic.to_positive_criterion()
 
 
 class ActionSelectionBehavior:

--- a/execution_engine/fhir_omop_mapping.py
+++ b/execution_engine/fhir_omop_mapping.py
@@ -38,7 +38,6 @@ def characteristic_to_criterion(
         )
         comb = LogicalCriterionCombination(
             category=CohortCategory.POPULATION,
-            exclude=False,
             operator=operator,
         )
         for c in characteristic:
@@ -48,7 +47,7 @@ def characteristic_to_criterion(
         else:
             return comb
     else:
-        return characteristic.to_positive_criterion()
+        return characteristic.to_criterion()
 
 
 class ActionSelectionBehavior:

--- a/execution_engine/fhir_omop_mapping.py
+++ b/execution_engine/fhir_omop_mapping.py
@@ -42,10 +42,11 @@ def characteristic_to_criterion(
         )
         for c in characteristic:
             comb.add(characteristic_to_criterion(c))
+
         if characteristic.exclude:
-            return LogicalCriterionCombination.Not(comb, CohortCategory.POPULATION)
-        else:
-            return comb
+            comb = LogicalCriterionCombination.Not(comb, CohortCategory.POPULATION)
+
+        return comb
     else:
         return characteristic.to_criterion()
 

--- a/execution_engine/omop/cohort/population_intervention_pair.py
+++ b/execution_engine/omop/cohort/population_intervention_pair.py
@@ -168,7 +168,7 @@ class PopulationInterventionPair(Serializable):
         """
         Assert that the base table is used in the select statement.
 
-        Joining the base table ensures that always just a subset of potients are selected,
+        Joining the base table ensures that always just a subset of patients is selected,
         not all.
         """
         if isinstance(sql, SelectInto) or isinstance(sql, Insert):

--- a/execution_engine/omop/cohort/population_intervention_pair.py
+++ b/execution_engine/omop/cohort/population_intervention_pair.py
@@ -69,7 +69,6 @@ class PopulationInterventionPair(Serializable):
         """
 
         root_combination = LogicalCriterionCombination(
-            exclude=False,
             category=category,
             operator=LogicalCriterionCombination.Operator("AND"),
             root_combination=True,

--- a/execution_engine/omop/cohort/recommendation.py
+++ b/execution_engine/omop/cohort/recommendation.py
@@ -164,7 +164,6 @@ class Recommendation(Serializable):
         Get the criteria of the recommendation.
         """
         criteria = LogicalCriterionCombination(
-            exclude=False,
             category=CohortCategory.BASE,
             operator=LogicalCriterionCombination.Operator("OR"),
             root_combination=True,

--- a/execution_engine/omop/criterion/abstract.py
+++ b/execution_engine/omop/criterion/abstract.py
@@ -96,6 +96,7 @@ class AbstractCriterion(Serializable, ABC):
     def __init__(self, exclude: bool, category: CohortCategory) -> None:
         self._id = None
         self._exclude: bool = exclude
+        assert exclude == False
 
         assert isinstance(
             category, CohortCategory

--- a/execution_engine/omop/criterion/abstract.py
+++ b/execution_engine/omop/criterion/abstract.py
@@ -93,26 +93,14 @@ class AbstractCriterion(Serializable, ABC):
     Abstract base class for Criterion and CriterionCombination.
     """
 
-    def __init__(self, exclude: bool, category: CohortCategory) -> None:
+    def __init__(self, category: CohortCategory) -> None:
         self._id = None
-        self._exclude: bool = exclude
-        assert exclude == False
 
         assert isinstance(
             category, CohortCategory
         ), f"category must be a CohortCategory, not {type(category)}"
 
         self._category: CohortCategory = category
-
-    @property
-    def exclude(self) -> bool:
-        """Return the exclude flag."""
-        return self._exclude
-
-    @exclude.setter
-    def exclude(self, exclude: bool) -> None:
-        """Sets the exclude value."""
-        self._exclude = exclude
 
     @property
     def category(self) -> CohortCategory:
@@ -132,18 +120,6 @@ class AbstractCriterion(Serializable, ABC):
         """
         return copy.copy(self)
 
-    def invert_exclude(self, inplace: bool = False) -> "AbstractCriterion":
-        """
-        Invert the exclude flag.
-        """
-        if inplace:
-            self._exclude = not self._exclude
-            return self
-        else:
-            criterion = self.copy()
-            criterion._exclude = not criterion._exclude
-            return criterion
-
     @abstractmethod
     def description(self) -> str:
         """
@@ -155,27 +131,13 @@ class AbstractCriterion(Serializable, ABC):
         """
         Get the representation of the criterion.
         """
-        return f"{self.type}.{self._category.name}.{self.description()}(exclude={self._exclude})"
+        return f"{self.type}.{self._category.name}.{self.description()}"
 
     def __str__(self) -> str:
         """
         Get the name of the criterion.
         """
         return self.description()
-
-    def clear_exclude(self, inplace: bool = False) -> "AbstractCriterion":
-        """
-        Clear the exclude flag.
-
-        :param inplace: If True, the exclude flag is cleared in place. Otherwise, a copy of the criterion is returned
-            with the exclude flag cleared.
-        :return: The criterion with the exclude flag cleared.
-        """
-
-        if not self.exclude:
-            return self
-        else:
-            return self.invert_exclude(inplace=inplace)
 
 
 class Criterion(AbstractCriterion):
@@ -248,8 +210,8 @@ class Criterion(AbstractCriterion):
     Flag to indicate whether the filter_datetime function has been called.
     """
 
-    def __init__(self, exclude: bool, category: CohortCategory) -> None:
-        super().__init__(exclude=exclude, category=category)
+    def __init__(self, category: CohortCategory) -> None:
+        super().__init__(category=category)
 
     def _set_omop_variables_from_domain(self, domain_id: str) -> None:
         """

--- a/execution_engine/omop/criterion/combination/combination.py
+++ b/execution_engine/omop/criterion/combination/combination.py
@@ -49,7 +49,6 @@ class CriterionCombination(AbstractCriterion, metaclass=ABCMeta):
 
     def __init__(
         self,
-        exclude: bool,
         operator: Operator,
         category: CohortCategory,
         criteria: Sequence[Union[Criterion, "CriterionCombination"]] | None = None,
@@ -58,7 +57,7 @@ class CriterionCombination(AbstractCriterion, metaclass=ABCMeta):
         """
         Initialize the criterion combination.
         """
-        super().__init__(exclude=exclude, category=category)
+        super().__init__(category=category)
         self._operator = operator
 
         self._criteria: list[Union[Criterion, CriterionCombination]]
@@ -89,7 +88,7 @@ class CriterionCombination(AbstractCriterion, metaclass=ABCMeta):
         """
         Get the name of the criterion combination.
         """
-        return f"{self.__class__.__name__}({self.operator}).{self.category.value}(exclude={self._exclude})"
+        return f"{self.__class__.__name__}({self.operator}).{self.category.value}"
 
     @property
     def operator(self) -> "CriterionCombination.Operator":
@@ -140,7 +139,6 @@ class CriterionCombination(AbstractCriterion, metaclass=ABCMeta):
         Get the dictionary representation of the criterion combination.
         """
         return {
-            "exclude": self._exclude,
             "operator": self._operator.operator,
             "threshold": self._operator.threshold,
             "category": self._category.value,
@@ -165,9 +163,7 @@ class CriterionCombination(AbstractCriterion, metaclass=ABCMeta):
         ):
             return self._criteria[0]
         else:
-            assert self._exclude is False
             copy = self.__class__(
-                exclude=False,
                 operator=self._operator,
                 category=self._category,
                 criteria=self._criteria,
@@ -194,7 +190,6 @@ class CriterionCombination(AbstractCriterion, metaclass=ABCMeta):
         category = CohortCategory(data["category"])
 
         combination = cls(
-            exclude=data["exclude"],
             operator=operator,
             category=category,
         )

--- a/execution_engine/omop/criterion/combination/logical.py
+++ b/execution_engine/omop/criterion/combination/logical.py
@@ -13,6 +13,7 @@ class LogicalCriterionCombination(CriterionCombination):
     class Operator(CriterionCombination.Operator):
         """Operators for criterion combinations."""
 
+        NOT = "NOT"
         AND = "AND"
         OR = "OR"
         AT_LEAST = "AT_LEAST"
@@ -22,6 +23,7 @@ class LogicalCriterionCombination(CriterionCombination):
 
         def __init__(self, operator: str, threshold: int | None = None):
             assert operator in [
+                "NOT",
                 "AND",
                 "OR",
                 "AT_LEAST",
@@ -36,6 +38,22 @@ class LogicalCriterionCombination(CriterionCombination):
                     threshold is not None
                 ), f"Threshold must be set for operator {operator}"
             self.threshold = threshold
+
+    @classmethod
+    def Not(
+        cls,
+        criterion: Union[Criterion, "CriterionCombination"],
+        category: CohortCategory,
+    ) -> "LogicalCriterionCombination":
+        """
+        Create a NOT "combination" of a single criterion.
+        """
+        return cls(
+            exclude=False,
+            operator=cls.Operator(cls.Operator.NOT),
+            category=category,
+            criteria=[criterion],
+        )
 
     @classmethod
     def And(

--- a/execution_engine/omop/criterion/combination/logical.py
+++ b/execution_engine/omop/criterion/combination/logical.py
@@ -49,7 +49,6 @@ class LogicalCriterionCombination(CriterionCombination):
         Create a NOT "combination" of a single criterion.
         """
         return cls(
-            exclude=False,
             operator=cls.Operator(cls.Operator.NOT),
             category=category,
             criteria=[criterion],
@@ -60,13 +59,11 @@ class LogicalCriterionCombination(CriterionCombination):
         cls,
         *criteria: Union[Criterion, "CriterionCombination"],
         category: CohortCategory,
-        exclude: bool = False,
     ) -> "LogicalCriterionCombination":
         """
         Create an AND combination of criteria.
         """
         return cls(
-            exclude=exclude,
             operator=cls.Operator(cls.Operator.AND),
             category=category,
             criteria=criteria,
@@ -77,13 +74,11 @@ class LogicalCriterionCombination(CriterionCombination):
         cls,
         *criteria: Union[Criterion, "CriterionCombination"],
         category: CohortCategory,
-        exclude: bool = False,
     ) -> "LogicalCriterionCombination":
         """
         Create an OR combination of criteria.
         """
         return cls(
-            exclude=exclude,
             operator=cls.Operator(cls.Operator.OR),
             category=category,
             criteria=criteria,
@@ -95,13 +90,11 @@ class LogicalCriterionCombination(CriterionCombination):
         *criteria: Union[Criterion, "CriterionCombination"],
         threshold: int,
         category: CohortCategory,
-        exclude: bool = False,
     ) -> "LogicalCriterionCombination":
         """
         Create an AT_LEAST combination of criteria.
         """
         return cls(
-            exclude=exclude,
             operator=cls.Operator(cls.Operator.AT_LEAST, threshold=threshold),
             category=category,
             criteria=criteria,
@@ -113,13 +106,11 @@ class LogicalCriterionCombination(CriterionCombination):
         *criteria: Union[Criterion, "CriterionCombination"],
         threshold: int,
         category: CohortCategory,
-        exclude: bool = False,
     ) -> "LogicalCriterionCombination":
         """
         Create an AT_MOST combination of criteria.
         """
         return cls(
-            exclude=exclude,
             operator=cls.Operator(cls.Operator.AT_MOST, threshold=threshold),
             category=category,
             criteria=criteria,
@@ -131,13 +122,11 @@ class LogicalCriterionCombination(CriterionCombination):
         *criteria: Union[Criterion, "LogicalCriterionCombination"],
         threshold: int,
         category: CohortCategory,
-        exclude: bool = False,
     ) -> "LogicalCriterionCombination":
         """
         Create an EXACTLY combination of criteria.
         """
         return cls(
-            exclude=exclude,
             operator=cls.Operator(cls.Operator.EXACTLY, threshold=threshold),
             category=category,
             criteria=criteria,
@@ -148,13 +137,11 @@ class LogicalCriterionCombination(CriterionCombination):
         cls,
         *criteria: Union[Criterion, "LogicalCriterionCombination"],
         category: CohortCategory,
-        exclude: bool = False,
     ) -> "LogicalCriterionCombination":
         """
         Create an ALL_OR_NONE combination of criteria.
         """
         return cls(
-            exclude=exclude,
             operator=cls.Operator(cls.Operator.ALL_OR_NONE),
             category=category,
             criteria=criteria,
@@ -184,7 +171,6 @@ class NonCommutativeLogicalCriterionCombination(LogicalCriterionCombination):
 
     def __init__(
         self,
-        exclude: bool,
         operator: "NonCommutativeLogicalCriterionCombination.Operator",
         category: CohortCategory,
         left: Union[Criterion, CriterionCombination] | None = None,
@@ -194,7 +180,7 @@ class NonCommutativeLogicalCriterionCombination(LogicalCriterionCombination):
         """
         Initialize the criterion combination.
         """
-        super().__init__(exclude=exclude, operator=operator, category=category)
+        super().__init__(operator=operator, category=category)
 
         self._criteria = []
         if left is not None:
@@ -240,7 +226,6 @@ class NonCommutativeLogicalCriterionCombination(LogicalCriterionCombination):
             self.operator == other.operator
             and self._left == other._left
             and self._right == other._right
-            and self.exclude == other.exclude
             and self.category == other.category
         )
 
@@ -259,7 +244,6 @@ class NonCommutativeLogicalCriterionCombination(LogicalCriterionCombination):
         right = self._right
         return {
             "operator": self._operator.operator,
-            "exclude": self.exclude,
             "category": self.category.value,
             "left": {"class_name": left.__class__.__name__, "data": left.dict()},
             "right": {"class_name": right.__class__.__name__, "data": right.dict()},
@@ -278,7 +262,6 @@ class NonCommutativeLogicalCriterionCombination(LogicalCriterionCombination):
         )
 
         return cls(
-            exclude=data["exclude"],
             operator=cls.Operator(data["operator"]),
             category=CohortCategory(data["category"]),
             left=criterion_factory(**data["left"]),
@@ -291,13 +274,11 @@ class NonCommutativeLogicalCriterionCombination(LogicalCriterionCombination):
         left: Union[Criterion, "CriterionCombination"],
         right: Union[Criterion, "CriterionCombination"],
         category: CohortCategory,
-        exclude: bool = False,
     ) -> "LogicalCriterionCombination":
         """
         Create a CONDITIONAL_FILTER combination of criteria.
         """
         return cls(
-            exclude=exclude,
             operator=cls.Operator(cls.Operator.CONDITIONAL_FILTER),
             category=category,
             left=left,

--- a/execution_engine/omop/criterion/combination/logical.py
+++ b/execution_engine/omop/criterion/combination/logical.py
@@ -277,6 +277,16 @@ class NonCommutativeLogicalCriterionCombination(LogicalCriterionCombination):
     ) -> "LogicalCriterionCombination":
         """
         Create a CONDITIONAL_FILTER combination of criteria.
+
+        A conditional filter returns `right` iff `left` is POSITIVE, otherwise NEGATIVE.
+
+        | left     | right    | Result   |
+        |----------|----------|----------|
+        | NEGATIVE |    *     | NEGATIVE |
+        | NO_DATA  |    *     | NEGATIVE |
+        | POSITIVE | POSITIVE | POSITIVE |
+        | POSITIVE | NEGATIVE | NEGATIVE |
+        | POSITIVE | NO_DATA  | NO_DATA  |
         """
         return cls(
             operator=cls.Operator(cls.Operator.CONDITIONAL_FILTER),

--- a/execution_engine/omop/criterion/combination/temporal.py
+++ b/execution_engine/omop/criterion/combination/temporal.py
@@ -62,9 +62,7 @@ class TemporalIndicatorCombination(CriterionCombination):
         else:
             criteria = None
 
-        super().__init__(
-            exclude=False, operator=operator, category=category, criteria=criteria
-        )
+        super().__init__(operator=operator, category=category, criteria=criteria)
 
         if interval_type:
             if start_time is not None or end_time is not None:
@@ -102,7 +100,6 @@ class TemporalIndicatorCombination(CriterionCombination):
         """
 
         d = super().dict()
-        del d["exclude"]
         d["start_time"] = self.start_time.isoformat() if self.start_time else None
         d["end_time"] = self.end_time.isoformat() if self.end_time else None
         d["interval_type"] = self.interval_type

--- a/execution_engine/omop/criterion/concept.py
+++ b/execution_engine/omop/criterion/concept.py
@@ -46,10 +46,9 @@ class ConceptCriterion(Criterion, ABC):
         value: Value | None = None,
         static: bool | None = None,
         timing: Timing | None = None,
-        exclude: bool = False,
         override_value_required: bool | None = None,
     ):
-        super().__init__(exclude=exclude, category=category)
+        super().__init__(category=category)
 
         self._set_omop_variables_from_domain(concept.domain_id)
         self._concept = concept
@@ -136,7 +135,6 @@ class ConceptCriterion(Criterion, ABC):
         Get a JSON representation of the criterion.
         """
         return {
-            "exclude": self._exclude,
             "category": self._category.value,
             "concept": self._concept.model_dump(),
             "value": (
@@ -159,7 +157,6 @@ class ConceptCriterion(Criterion, ABC):
         """
 
         return cls(
-            exclude=data["exclude"],
             category=CohortCategory(data["category"]),
             concept=Concept(**data["concept"]),
             value=(

--- a/execution_engine/omop/criterion/custom/tidal_volume.py
+++ b/execution_engine/omop/criterion/custom/tidal_volume.py
@@ -1,3 +1,4 @@
+import numbers
 from typing import Any
 
 import sqlalchemy
@@ -229,7 +230,7 @@ class TidalVolumePerIdealBodyWeight(PointInTimeCriterion):
 
     @classmethod
     def height_for_predicted_body_weight_ardsnet(
-        self, gender: str, predicted_weight: float
+        self, gender: str, predicted_weight: numbers.Real
     ) -> float:
         """
         Height for predicted body weight according to ARDSNet
@@ -238,7 +239,11 @@ class TidalVolumePerIdealBodyWeight(PointInTimeCriterion):
             raise ValueError(
                 f"Unrecognized gender {gender}, must be one of {self.__GENDER_TO_INT.keys()}"
             )
+        if not isinstance(predicted_weight, numbers.Real):
+            raise ValueError(
+                f"predicted_weight must be of type float, not {type(predicted_weight)}"
+            )
 
-        return (
+        return (  # type: ignore
             predicted_weight - (45.5 + (4.5 * self.__GENDER_TO_INT[gender]))
         ) / 0.91 + 152.4

--- a/execution_engine/omop/criterion/drug_exposure.py
+++ b/execution_engine/omop/criterion/drug_exposure.py
@@ -29,7 +29,6 @@ class DrugExposure(Criterion):
 
     def __init__(
         self,
-        exclude: bool,
         category: CohortCategory,
         ingredient_concept: Concept,
         dose: Dosage | None,
@@ -38,7 +37,7 @@ class DrugExposure(Criterion):
         """
         Initialize the drug administration action.
         """
-        super().__init__(exclude=exclude, category=category)
+        super().__init__(category=category)
         self._set_omop_variables_from_domain("drug")
         self._ingredient_concept = ingredient_concept
 
@@ -357,7 +356,6 @@ class DrugExposure(Criterion):
         Return a dictionary representation of the criterion.
         """
         return {
-            "exclude": self._exclude,
             "category": self._category.value,
             "ingredient_concept": self._ingredient_concept.model_dump(),
             "dose": (
@@ -379,7 +377,6 @@ class DrugExposure(Criterion):
         assert dose is None or isinstance(dose, Dosage), "Dose must be a Dosage or None"
 
         return cls(
-            exclude=data["exclude"],
             category=CohortCategory(data["category"]),
             ingredient_concept=Concept(**data["ingredient_concept"]),
             dose=dose,

--- a/execution_engine/omop/criterion/point_in_time.py
+++ b/execution_engine/omop/criterion/point_in_time.py
@@ -125,7 +125,7 @@ class PointInTimeCriterion(ConceptCriterion):
         :param observation_window: The observation window.
         :return: A processed DataFrame.
         """
-        # todo: the probleme here is that this merges intervals that are days apart -
+        # todo: the problem here is that this merges intervals that are days apart -
         #        but on the other hand, for any AND combination of measurement values,
         #        we need to extend the duration of these point in time criteria (such as measurements)
         #        because they are valid not only at the time of the measurement but also for a certain time after the

--- a/execution_engine/omop/criterion/procedure_occurrence.py
+++ b/execution_engine/omop/criterion/procedure_occurrence.py
@@ -24,7 +24,6 @@ class ProcedureOccurrence(ContinuousCriterion):
 
     def __init__(
         self,
-        exclude: bool,
         category: CohortCategory,
         concept: Concept,
         value: ValueNumber | None = None,
@@ -32,7 +31,6 @@ class ProcedureOccurrence(ContinuousCriterion):
         static: bool | None = None,
     ) -> None:
         super().__init__(
-            exclude=exclude,
             category=category,
             concept=concept,
             value=value,
@@ -160,7 +158,6 @@ class ProcedureOccurrence(ContinuousCriterion):
         assert self._concept is not None, "Concept must be set"
 
         return {
-            "exclude": self._exclude,
             "category": self._category.value,
             "concept": self._concept.model_dump(),
             "value": (
@@ -192,7 +189,6 @@ class ProcedureOccurrence(ContinuousCriterion):
         ), "timing must be a ValueNumber"
 
         return cls(
-            exclude=data["exclude"],
             category=CohortCategory(data["category"]),
             concept=Concept(**data["concept"]),
             value=value,

--- a/execution_engine/omop/criterion/visit_occurrence.py
+++ b/execution_engine/omop/criterion/visit_occurrence.py
@@ -24,7 +24,6 @@ class ActivePatients(VisitOccurrence):
     """
 
     def __init__(self) -> None:
-        self._exclude = False
         self._category = CohortCategory.BASE
 
         if get_config().episode_of_care_visit_detail:

--- a/tests/execution_engine/converter/action/test_assessment.py
+++ b/tests/execution_engine/converter/action/test_assessment.py
@@ -33,7 +33,7 @@ class TestAssessmentAction:
     def test_assessment_action(self, code, timing, criterion_class):
         action = AssessmentAction(exclude=False, code=code, timing=timing)
 
-        criterion = action.to_criterion()
+        criterion = action.to_positive_criterion()
 
         assert isinstance(criterion, criterion_class)
         assert criterion._concept == code

--- a/tests/execution_engine/converter/action/test_assessment.py
+++ b/tests/execution_engine/converter/action/test_assessment.py
@@ -33,7 +33,7 @@ class TestAssessmentAction:
     def test_assessment_action(self, code, timing, criterion_class):
         action = AssessmentAction(exclude=False, code=code, timing=timing)
 
-        criterion = action.to_positive_criterion()
+        criterion = action.to_criterion()
 
         assert isinstance(criterion, criterion_class)
         assert criterion._concept == code

--- a/tests/execution_engine/converter/action/test_drug_administration.py
+++ b/tests/execution_engine/converter/action/test_drug_administration.py
@@ -26,7 +26,7 @@ class TestDrugAdministration:
             dosages=[dosage_def],
         )
 
-        criterion = action.to_positive_criterion()
+        criterion = action.to_criterion()
 
         assert isinstance(criterion, DrugExposure)
         assert criterion._dose == dosage
@@ -64,7 +64,7 @@ class TestDrugAdministration:
             ],
         )
 
-        comb = action.to_positive_criterion()
+        comb = action.to_criterion()
         criteria = list(comb)
 
         assert len(criteria) == 3

--- a/tests/execution_engine/converter/action/test_drug_administration.py
+++ b/tests/execution_engine/converter/action/test_drug_administration.py
@@ -26,7 +26,7 @@ class TestDrugAdministration:
             dosages=[dosage_def],
         )
 
-        criterion = action.to_criterion()
+        criterion = action.to_positive_criterion()
 
         assert isinstance(criterion, DrugExposure)
         assert criterion._dose == dosage
@@ -64,7 +64,7 @@ class TestDrugAdministration:
             ],
         )
 
-        comb = action.to_criterion()
+        comb = action.to_positive_criterion()
         criteria = list(comb)
 
         assert len(criteria) == 3

--- a/tests/execution_engine/converter/test_converter.py
+++ b/tests/execution_engine/converter/test_converter.py
@@ -155,7 +155,7 @@ class TestCriterionConverter:
         def valid(cls, fhir_definition: Element) -> bool:
             return fhir_definition.id == "valid"
 
-        def to_criterion(self) -> Criterion | LogicalCriterionCombination:
+        def to_positive_criterion(self) -> Criterion | LogicalCriterionCombination:
             raise NotImplementedError()
 
     def test_criterion_converter_factory_register(self):

--- a/tests/execution_engine/omop/criterion/combination/test_logical_combination.py
+++ b/tests/execution_engine/omop/criterion/combination/test_logical_combination.py
@@ -64,7 +64,6 @@ class TestCriterionCombination:
             LogicalCriterionCombination.Operator.AND
         )
         combination = LogicalCriterionCombination(
-            exclude=False,
             operator=operator,
             category=CohortCategory.POPULATION_INTERVENTION,
         )
@@ -77,7 +76,6 @@ class TestCriterionCombination:
             LogicalCriterionCombination.Operator.AND
         )
         combination = LogicalCriterionCombination(
-            exclude=False,
             operator=operator,
             category=CohortCategory.POPULATION_INTERVENTION,
         )
@@ -95,7 +93,6 @@ class TestCriterionCombination:
             LogicalCriterionCombination.Operator.AND
         )
         combination = LogicalCriterionCombination(
-            exclude=False,
             operator=operator,
             category=CohortCategory.POPULATION_INTERVENTION,
         )
@@ -105,7 +102,6 @@ class TestCriterionCombination:
 
         combination_dict = combination.dict()
         assert combination_dict == {
-            "exclude": False,
             "operator": "AND",
             "threshold": None,
             "category": "POPULATION_INTERVENTION",
@@ -120,7 +116,6 @@ class TestCriterionCombination:
             LogicalCriterionCombination.Operator.AND
         )
         combination_data = {
-            "exclude": False,
             "operator": "AND",
             "threshold": None,
             "category": "POPULATION_INTERVENTION",
@@ -161,7 +156,6 @@ class TestCriterionCombination:
         factory.register_criterion_class("MockCriterion", MockCriterion)
 
         combination = LogicalCriterionCombination(
-            exclude=False,
             operator=operator,
             category=CohortCategory.POPULATION_INTERVENTION,
         )
@@ -184,7 +178,6 @@ class TestCriterionCombination:
             NonCommutativeLogicalCriterionCombination.Operator.CONDITIONAL_FILTER
         )
         combination = NonCommutativeLogicalCriterionCombination(
-            exclude=False,
             operator=operator,
             category=CohortCategory.POPULATION_INTERVENTION,
             left=mock_criteria[0],
@@ -225,14 +218,13 @@ class TestCriterionCombination:
             LogicalCriterionCombination.Operator.AND
         )
         combination = LogicalCriterionCombination(
-            exclude=False,
             operator=operator,
             category=CohortCategory.POPULATION_INTERVENTION,
         )
 
         assert (
             repr(combination)
-            == "LogicalCriterionCombination(AND).POPULATION_INTERVENTION(exclude=False)"
+            == "LogicalCriterionCombination(AND).POPULATION_INTERVENTION"
         )
 
     def test_add_all(self):
@@ -240,7 +232,6 @@ class TestCriterionCombination:
             LogicalCriterionCombination.Operator.AND
         )
         combination = LogicalCriterionCombination(
-            exclude=False,
             operator=operator,
             category=CohortCategory.POPULATION_INTERVENTION,
         )
@@ -269,7 +260,6 @@ class TestCriterionCombinationDatabase(TestCriterion):
     @pytest.fixture
     def criteria(self, db_session):
         c1 = DrugExposure(
-            exclude=False,
             category=CohortCategory.POPULATION,
             ingredient_concept=concept_heparin_ingredient,
             dose=Dosage(
@@ -281,13 +271,11 @@ class TestCriterionCombinationDatabase(TestCriterion):
         )
 
         c2 = ConditionOccurrence(
-            exclude=False,
             category=CohortCategory.POPULATION,
             concept=concept_covid19,
         )
 
         c3 = ProcedureOccurrence(
-            exclude=False,
             category=CohortCategory.POPULATION,
             concept=concept_artificial_respiration,
         )
@@ -368,7 +356,6 @@ class TestCriterionCombinationDatabase(TestCriterion):
             assert len(c.args) == 2
 
             comb = NonCommutativeLogicalCriterionCombination.ConditionalFilter(
-                exclude=False,
                 category=CohortCategory.POPULATION,
                 left=symbols[str(c.args[0])],
                 right=symbols[str(c.args[1])],
@@ -376,7 +363,6 @@ class TestCriterionCombinationDatabase(TestCriterion):
 
         else:
             comb = LogicalCriterionCombination(
-                exclude=False,
                 category=CohortCategory.POPULATION,
                 operator=LogicalCriterionCombination.Operator(
                     operator, threshold=threshold
@@ -738,7 +724,6 @@ class TestCriterionCombinationNoData(TestCriterionCombinationDatabase):
     @pytest.fixture
     def criteria(self, db_session):
         c1 = DrugExposure(
-            exclude=False,
             category=CohortCategory.POPULATION,
             ingredient_concept=concept_heparin_ingredient,
             dose=Dosage(
@@ -750,14 +735,12 @@ class TestCriterionCombinationNoData(TestCriterionCombinationDatabase):
         )
 
         c2 = Measurement(
-            exclude=False,
             category=CohortCategory.POPULATION,
             concept=concept_tidal_volume,
             value=ValueNumber(value_min=500, unit=concept_unit_ml),
         )
 
         c3 = Measurement(
-            exclude=False,
             category=CohortCategory.POPULATION,
             concept=concept_body_weight,
             value=ValueNumber(value_min=70, unit=concept_unit_kg),
@@ -875,7 +858,6 @@ class TestCriterionCombinationConditionalFilter(TestCriterionCombinationDatabase
     @pytest.fixture
     def criteria(self, db_session):
         c1 = DrugExposure(
-            exclude=False,
             category=CohortCategory.POPULATION,
             ingredient_concept=concept_heparin_ingredient,
             dose=Dosage(
@@ -887,14 +869,12 @@ class TestCriterionCombinationConditionalFilter(TestCriterionCombinationDatabase
         )
 
         c2 = Measurement(
-            exclude=False,
             category=CohortCategory.POPULATION,
             concept=concept_body_weight,
             value=ValueNumber(value_min=70, unit=concept_unit_kg),
         )
 
         c3 = ConditionOccurrence(
-            exclude=False,
             category=CohortCategory.POPULATION,
             concept=concept_covid19,
         )

--- a/tests/execution_engine/omop/criterion/combination/test_temporal_combination.py
+++ b/tests/execution_engine/omop/criterion/combination/test_temporal_combination.py
@@ -212,7 +212,7 @@ class TestTemporalIndicatorCombination:
 
         assert (
             repr(combination)
-            == "TemporalIndicatorCombination(AT_LEAST(threshold=1)).POPULATION_INTERVENTION(exclude=False) for morning_shift"
+            == "TemporalIndicatorCombination(AT_LEAST(threshold=1)).POPULATION_INTERVENTION for morning_shift"
         )
 
         combination = TemporalIndicatorCombination(
@@ -224,7 +224,7 @@ class TestTemporalIndicatorCombination:
 
         assert (
             repr(combination)
-            == "TemporalIndicatorCombination(AT_LEAST(threshold=1)).POPULATION_INTERVENTION(exclude=False) from 08:00:00 to 16:00:00"
+            == "TemporalIndicatorCombination(AT_LEAST(threshold=1)).POPULATION_INTERVENTION from 08:00:00 to 16:00:00"
         )
 
     def test_add_all(self):
@@ -248,7 +248,6 @@ class TestTemporalIndicatorCombination:
 
 
 c1 = DrugExposure(
-    exclude=False,
     category=CohortCategory.POPULATION,
     ingredient_concept=concept_heparin_ingredient,
     dose=Dosage(
@@ -260,19 +259,16 @@ c1 = DrugExposure(
 )
 
 c2 = ConditionOccurrence(
-    exclude=False,
     category=CohortCategory.POPULATION,
     concept=concept_covid19,
 )
 
 c3 = ProcedureOccurrence(
-    exclude=False,
     category=CohortCategory.POPULATION,
     concept=concept_artificial_respiration,
 )
 
 bodyweight_measurement_without_forward_fill = Measurement(
-    exclude=False,
     category=CohortCategory.POPULATION,
     concept=concept_body_weight,
     value=ValueNumber.parse("<=110", unit=concept_unit_kg),
@@ -281,7 +277,6 @@ bodyweight_measurement_without_forward_fill = Measurement(
 )
 
 bodyweight_measurement_with_forward_fill = Measurement(
-    exclude=False,
     category=CohortCategory.POPULATION,
     concept=concept_body_weight,
     value=ValueNumber.parse("<=110", unit=concept_unit_kg),

--- a/tests/execution_engine/omop/criterion/custom/test_tidal_volume.py
+++ b/tests/execution_engine/omop/criterion/custom/test_tidal_volume.py
@@ -213,9 +213,11 @@ class TestTidalVolumePerIdealBodyWeight(TestCriterion):
         ],
         ids=["tv/bw=5.9_"] * 3 + ["tv/bw=6.0_"] * 3 + ["tv/bw=6.1_"] * 3,
     )  # time ranges used in the database entry
-    @pytest.mark.parametrize(
-        "exclude", [True, False], ids=["exclude=True", "exclude=False"]
-    )  # exclude used in the criterion
+    # todo: implement proper exclude=True test (currently, insert_criterion does not handle it properly, also
+    #  "expected" must be adapted then)
+    # @pytest.mark.parametrize(
+    #     "exclude", [True, False], ids=["exclude=True", "exclude=False"]
+    # )  # exclude used in the criterion
     @pytest.mark.parametrize(
         "threshold", [6], ids=["threshold=6"]
     )  # threshold used in the criterion
@@ -230,7 +232,6 @@ class TestTidalVolumePerIdealBodyWeight(TestCriterion):
         person_visit,
         db_session,
         observation_window,
-        exclude,
         criterion_execute_func,
     ):
         from execution_engine.clients import omopdb
@@ -263,9 +264,9 @@ class TestTidalVolumePerIdealBodyWeight(TestCriterion):
         )
 
         # run criterion against db
-        df = criterion_execute_func(
-            concept=concept, value=value, exclude=exclude
-        ).query(f"{p.person_id} == person_id")
+        df = criterion_execute_func(concept=concept, value=value).query(
+            f"{p.person_id} == person_id"
+        )
 
         assert set(df["valid_date"].dt.date) == self.date_points(expected)
 
@@ -356,7 +357,7 @@ class TestTidalVolumePerIdealBodyWeight(TestCriterion):
         )
 
         # run criterion against db
-        df = criterion_execute_func(concept=concept, value=value, exclude=False).query(
+        df = criterion_execute_func(concept=concept, value=value).query(
             f"{p.person_id} == person_id"
         )
 
@@ -427,7 +428,7 @@ class TestTidalVolumePerIdealBodyWeight(TestCriterion):
             tvs=[{"time": "2023-03-04 07:00:00+01:00", "value": tidal_volume}],
         )
         expected = []
-        df = criterion_execute_func(concept=concept, value=value, exclude=False).query(
+        df = criterion_execute_func(concept=concept, value=value).query(
             f"{p.person_id} == person_id"
         )
 
@@ -453,7 +454,7 @@ class TestTidalVolumePerIdealBodyWeight(TestCriterion):
         )
         expected = ["2023-03-04"]
 
-        df = criterion_execute_func(concept=concept, value=value, exclude=False).query(
+        df = criterion_execute_func(concept=concept, value=value).query(
             f"{p.person_id} == person_id"
         )
 
@@ -482,7 +483,7 @@ class TestTidalVolumePerIdealBodyWeight(TestCriterion):
         )
         expected = []
 
-        df = criterion_execute_func(concept=concept, value=value, exclude=False).query(
+        df = criterion_execute_func(concept=concept, value=value).query(
             f"{p.person_id} == person_id"
         )
 
@@ -490,7 +491,7 @@ class TestTidalVolumePerIdealBodyWeight(TestCriterion):
 
         self.clean_measurements(db_session)
 
-        df = criterion_execute_func(concept=concept, value=value, exclude=False).query(
+        df = criterion_execute_func(concept=concept, value=value).query(
             f"{p.person_id} == person_id"
         )
 
@@ -519,7 +520,7 @@ class TestTidalVolumePerIdealBodyWeight(TestCriterion):
         )
         expected = ["2023-03-04"]
 
-        df = criterion_execute_func(concept=concept, value=value, exclude=False).query(
+        df = criterion_execute_func(concept=concept, value=value).query(
             f"{p.person_id} == person_id"
         )
 

--- a/tests/execution_engine/omop/criterion/custom/test_tidal_volume.py
+++ b/tests/execution_engine/omop/criterion/custom/test_tidal_volume.py
@@ -672,4 +672,5 @@ class TestTidalVolumePerIdealBodyWeight(TestCriterion):
         # Test the function for some invalid inputs
         with pytest.raises(ValueError):
             TVPIBW.height_for_predicted_body_weight_ardsnet(1, 76.42)
+        with pytest.raises(ValueError):
             TVPIBW.height_for_predicted_body_weight_ardsnet("male", "76.42")

--- a/tests/execution_engine/omop/criterion/test_criterion.py
+++ b/tests/execution_engine/omop/criterion/test_criterion.py
@@ -398,7 +398,6 @@ class TestCriterion:
             value: ValueNumber | ValueConcept | None = None,
         ) -> pd.DataFrame:
             criterion = criterion_class(
-                exclude=False,
                 category=CohortCategory.POPULATION,
                 concept=concept,
                 value=value,

--- a/tests/execution_engine/omop/criterion/test_drug_exposure.py
+++ b/tests/execution_engine/omop/criterion/test_drug_exposure.py
@@ -4,6 +4,9 @@ import pytest
 
 from execution_engine.constants import CohortCategory
 from execution_engine.omop.concepts import Concept
+from execution_engine.omop.criterion.combination.logical import (
+    LogicalCriterionCombination,
+)
 from execution_engine.omop.criterion.drug_exposure import DrugExposure
 from execution_engine.util.enum import TimeUnit
 from execution_engine.util.types import Dosage
@@ -35,12 +38,15 @@ class TestDrugExposure(TestCriterion):
             route: Concept | None,
         ) -> pd.DataFrame:
             criterion = DrugExposure(
-                exclude=exclude,
                 category=CohortCategory.POPULATION,
                 ingredient_concept=ingredient_concept,
                 dose=dose,
                 route=route,
             )
+            if exclude:
+                criterion = LogicalCriterionCombination.Not(
+                    criterion, category=criterion.category
+                )
 
             self.insert_criterion(db_session, criterion, observation_window)
 

--- a/tests/execution_engine/omop/criterion/test_occurrence_criterion.py
+++ b/tests/execution_engine/omop/criterion/test_occurrence_criterion.py
@@ -230,7 +230,7 @@ class Occurrence(TestCriterion, ABC):
                 self.insert_occurrences(concept, db_session, vo, time_ranges)
 
             # run criterion against db
-            df = criterion_execute_func(concept=concept, exclude=False)
+            df = criterion_execute_func(concept=concept)
 
         for test_case, vo in zip(test_cases, vos):
             assert set(
@@ -294,7 +294,7 @@ class Occurrence(TestCriterion, ABC):
 
         with self.disable_trigger_for_overlapping_intervals(time_ranges)(db_session):
             self.insert_occurrences(concept, db_session, vo, time_ranges)
-            df = criterion_execute_func(concept=concept, exclude=False)
+            df = criterion_execute_func(concept=concept)
 
         valid_daterange = self.date_ranges(filtered_time_ranges)
 

--- a/tests/execution_engine/omop/criterion/test_procedure_occurrence.py
+++ b/tests/execution_engine/omop/criterion/test_procedure_occurrence.py
@@ -2,9 +2,6 @@ import pytest
 
 from execution_engine.constants import CohortCategory
 from execution_engine.omop.concepts import Concept
-from execution_engine.omop.criterion.combination.logical import (
-    LogicalCriterionCombination,
-)
 from execution_engine.omop.criterion.procedure_occurrence import ProcedureOccurrence
 from execution_engine.util.enum import TimeUnit
 from execution_engine.util.types import TimeRange, Timing
@@ -61,7 +58,6 @@ class TestProcedureOccurrence(Occurrence):
 
         def criterion_execute_func_timing(
             concept: Concept,
-            exclude: bool,
             value: ValueNumber | None = None,
         ):
             timing = Timing(duration=2 * TimeUnit.HOUR)
@@ -73,10 +69,7 @@ class TestProcedureOccurrence(Occurrence):
                 timing=timing,
                 static=None,
             )
-            if exclude:
-                criterion = LogicalCriterionCombination.Not(
-                    criterion, category=criterion.category
-                )
+
             self.insert_criterion(db_session, criterion, observation_window)
             df = self.fetch_full_day_result(
                 db_session,
@@ -233,7 +226,6 @@ class TestProcedureOccurrence(Occurrence):
 
         def criterion_execute_func_timing(
             concept: Concept,
-            exclude: bool,
             value: ValueNumber | None = None,
         ):
             criterion = ProcedureOccurrence(
@@ -243,10 +235,7 @@ class TestProcedureOccurrence(Occurrence):
                 timing=timing,
                 static=None,
             )
-            if exclude:
-                criterion = LogicalCriterionCombination.Not(
-                    criterion, criterion.category
-                )
+
             self.insert_criterion(db_session, criterion, observation_window)
 
             df = self.fetch_interval_result(
@@ -265,7 +254,7 @@ class TestProcedureOccurrence(Occurrence):
         self.insert_occurrences(concept, db_session, vo, time_ranges)
 
         # run criterion against db
-        intervals = criterion_execute_func_timing(concept=concept, exclude=False)
+        intervals = criterion_execute_func_timing(concept=concept)
 
         assert set(intervals) == expected_intervals
 
@@ -328,7 +317,6 @@ class TestProcedureOccurrence(Occurrence):
 
         def criterion_execute_func_timing(
             concept: Concept,
-            exclude: bool,
             value: ValueNumber | None = None,
         ):
             criterion = ProcedureOccurrence(
@@ -356,7 +344,7 @@ class TestProcedureOccurrence(Occurrence):
         self.insert_occurrences(concept, db_session, vo, time_ranges)
 
         # run criterion against db
-        intervals = criterion_execute_func_timing(concept=concept, exclude=False)
+        intervals = criterion_execute_func_timing(concept=concept)
 
         assert set(intervals) == expected_intervals
 

--- a/tests/execution_engine/omop/criterion/test_procedure_occurrence.py
+++ b/tests/execution_engine/omop/criterion/test_procedure_occurrence.py
@@ -67,7 +67,6 @@ class TestProcedureOccurrence(Occurrence):
             timing = Timing(duration=2 * TimeUnit.HOUR)
 
             criterion = ProcedureOccurrence(
-                exclude=False,
                 category=CohortCategory.POPULATION,
                 concept=concept,
                 value=value,
@@ -238,7 +237,6 @@ class TestProcedureOccurrence(Occurrence):
             value: ValueNumber | None = None,
         ):
             criterion = ProcedureOccurrence(
-                exclude=False,
                 category=CohortCategory.POPULATION,
                 concept=concept,
                 value=value,
@@ -334,7 +332,6 @@ class TestProcedureOccurrence(Occurrence):
             value: ValueNumber | None = None,
         ):
             criterion = ProcedureOccurrence(
-                exclude=exclude,
                 category=CohortCategory.POPULATION,
                 concept=concept,
                 value=value,
@@ -365,7 +362,6 @@ class TestProcedureOccurrence(Occurrence):
 
     def test_serialization(self, concept):
         original = ProcedureOccurrence(
-            exclude=False,
             category=CohortCategory.POPULATION,
             concept=concept,
             value=None,

--- a/tests/execution_engine/omop/criterion/test_procedure_occurrence.py
+++ b/tests/execution_engine/omop/criterion/test_procedure_occurrence.py
@@ -2,6 +2,9 @@ import pytest
 
 from execution_engine.constants import CohortCategory
 from execution_engine.omop.concepts import Concept
+from execution_engine.omop.criterion.combination.logical import (
+    LogicalCriterionCombination,
+)
 from execution_engine.omop.criterion.procedure_occurrence import ProcedureOccurrence
 from execution_engine.util.enum import TimeUnit
 from execution_engine.util.types import TimeRange, Timing
@@ -64,13 +67,17 @@ class TestProcedureOccurrence(Occurrence):
             timing = Timing(duration=2 * TimeUnit.HOUR)
 
             criterion = ProcedureOccurrence(
-                exclude=exclude,
+                exclude=False,
                 category=CohortCategory.POPULATION,
                 concept=concept,
                 value=value,
                 timing=timing,
                 static=None,
             )
+            if exclude:
+                criterion = LogicalCriterionCombination.Not(
+                    criterion, category=criterion.category
+                )
             self.insert_criterion(db_session, criterion, observation_window)
             df = self.fetch_full_day_result(
                 db_session,
@@ -231,13 +238,17 @@ class TestProcedureOccurrence(Occurrence):
             value: ValueNumber | None = None,
         ):
             criterion = ProcedureOccurrence(
-                exclude=exclude,
+                exclude=False,
                 category=CohortCategory.POPULATION,
                 concept=concept,
                 value=value,
                 timing=timing,
                 static=None,
             )
+            if exclude:
+                criterion = LogicalCriterionCombination.Not(
+                    criterion, criterion.category
+                )
             self.insert_criterion(db_session, criterion, observation_window)
 
             df = self.fetch_interval_result(
@@ -354,7 +365,7 @@ class TestProcedureOccurrence(Occurrence):
 
     def test_serialization(self, concept):
         original = ProcedureOccurrence(
-            exclude=True,
+            exclude=False,
             category=CohortCategory.POPULATION,
             concept=concept,
             value=None,

--- a/tests/execution_engine/omop/criterion/test_value_criterion.py
+++ b/tests/execution_engine/omop/criterion/test_value_criterion.py
@@ -112,7 +112,6 @@ class ValueCriterion(TestCriterion, ABC):
             ],
         ],
     )  # time ranges used in the database entry
-    @pytest.mark.parametrize("exclude", [False])  # exclude used in the criterion
     @pytest.mark.parametrize(
         "criterion_value",
         [
@@ -131,7 +130,6 @@ class ValueCriterion(TestCriterion, ABC):
         criterion_execute_func,
         observation_window,
         times,
-        exclude,
         criterion_value,
         criterion_fixture,
     ):
@@ -142,7 +140,6 @@ class ValueCriterion(TestCriterion, ABC):
             criterion_execute_func=criterion_execute_func,
             observation_window=observation_window,
             times=times,
-            exclude=exclude,
             criterion_concept=criterion_fixture["concept"],
             criterion_unit_concept=criterion_fixture["unit_concept"],
             criterion_value=criterion_value,
@@ -193,7 +190,6 @@ class ValueCriterion(TestCriterion, ABC):
             criterion_execute_func=criterion_execute_func,
             observation_window=observation_window,
             times=times,
-            exclude=False,
             criterion_concept=criterion_fixture["concept"],
             criterion_unit_concept=criterion_fixture["unit_concept"],
             criterion_value=criterion_value,
@@ -203,7 +199,6 @@ class ValueCriterion(TestCriterion, ABC):
     @pytest.mark.parametrize(
         "times", [["2023-03-04 18:00:00"]]
     )  # time ranges used in the database entry
-    @pytest.mark.parametrize("exclude", [True])  # exclude used in the criterion
     @pytest.mark.parametrize(
         "criterion_value",
         [
@@ -218,7 +213,6 @@ class ValueCriterion(TestCriterion, ABC):
         criterion_execute_func,
         observation_window,
         times,
-        exclude,
         criterion_value,
         criterion_fixture,
     ):
@@ -230,7 +224,6 @@ class ValueCriterion(TestCriterion, ABC):
                 criterion_execute_func=criterion_execute_func,
                 observation_window=observation_window,
                 times=times,
-                exclude=exclude,
                 criterion_concept=criterion_fixture["concept"],
                 criterion_unit_concept=criterion_fixture["unit_concept"],
                 criterion_value=criterion_value,
@@ -253,7 +246,6 @@ class ValueCriterion(TestCriterion, ABC):
             ],
         ],
     )  # time ranges used in the database entry
-    @pytest.mark.parametrize("exclude", [False])  # exclude used in the criterion
     @pytest.mark.parametrize(
         "criterion_value",
         [  # value used in the criterion
@@ -269,7 +261,6 @@ class ValueCriterion(TestCriterion, ABC):
         criterion_execute_func,
         observation_window,
         times,
-        exclude,
         criterion_value,
         criterion_fixture,
     ):
@@ -280,7 +271,6 @@ class ValueCriterion(TestCriterion, ABC):
             criterion_execute_func=criterion_execute_func,
             observation_window=observation_window,
             times=times,
-            exclude=exclude,
             criterion_concept=criterion_fixture["concept"],
             criterion_unit_concept=criterion_fixture["unit_concept"],
             criterion_value={
@@ -298,7 +288,6 @@ class ValueCriterion(TestCriterion, ABC):
         criterion_execute_func,
         observation_window,
         times,
-        exclude,
         criterion_concept,
         criterion_unit_concept,
         criterion_value,
@@ -335,9 +324,9 @@ class ValueCriterion(TestCriterion, ABC):
             raise ValueError(f"Unknown value type: {type(criterion_value['value'])}")
 
         # run criterion against db
-        df = criterion_execute_func(
-            concept=criterion_concept, value=value, exclude=exclude
-        ).query(f"{p.person_id} == person_id")
+        df = criterion_execute_func(concept=criterion_concept, value=value).query(
+            f"{p.person_id} == person_id"
+        )
 
         criterion_matches = (
             criterion_value["match"]
@@ -385,7 +374,6 @@ class ValueCriterion(TestCriterion, ABC):
             ],
         ],
     )
-    @pytest.mark.parametrize("exclude", [False])  # exclude used in the criterion
     def test_value_multiple_persons(
         self,
         person_visit,
@@ -395,7 +383,6 @@ class ValueCriterion(TestCriterion, ABC):
         concept,
         unit_concept,
         test_cases,
-        exclude,
     ):
         vos = [pv[1] for pv in person_visit]
 
@@ -417,7 +404,7 @@ class ValueCriterion(TestCriterion, ABC):
         value = ValueNumber.parse(tc["criterion_value"], unit=unit_concept)
 
         # run criterion against db
-        df = criterion_execute_func(concept=concept, value=value, exclude=exclude)
+        df = criterion_execute_func(concept=concept, value=value)
 
         for vo, tc in zip(vos, test_cases):
             df_person = df.query(f"{vo.person_id} == person_id")

--- a/tests/execution_engine/omop/criterion/test_visit_occurrence.py
+++ b/tests/execution_engine/omop/criterion/test_visit_occurrence.py
@@ -358,7 +358,7 @@ class TestVisitOccurrence(TestCriterion):
             with self.execute_base_criterion(
                 base_criterion, db_session, observation_window
             ):
-                df = criterion_execute_func(concept=concept, exclude=False)
+                df = criterion_execute_func(concept=concept)
 
         assert set(df["valid_date"].dt.date) == date_set(expected)
 
@@ -447,7 +447,7 @@ class TestVisitOccurrence(TestCriterion):
                 base_criterion, db_session, observation_window
             ):
                 # run criterion against db
-                df = criterion_execute_func(concept=concept, exclude=False)
+                df = criterion_execute_func(concept=concept)
 
         for tc, p in zip(test_cases, person):
             assert set(

--- a/tests/mocks/criterion.py
+++ b/tests/mocks/criterion.py
@@ -21,6 +21,7 @@ class MockCriterion(Criterion):
         self._name = name
         self._exclude = exclude
         self._category = category
+        assert not exclude
 
     def unique_name(self) -> str:
         return self._name

--- a/tests/recommendation/test_recommendation_base.py
+++ b/tests/recommendation/test_recommendation_base.py
@@ -606,7 +606,7 @@ class TestRecommendationBase(ABC):
         Generates a list of unique criteria names extracted from recommendation expressions.
 
         This function utilizes `get_criteria_name_and_comparator` to fetch all criteria names along with their
-         omparators, then filters out the comparator information to provide a list of unique criteria names.
+        comparators, then filters out the comparator information to provide a list of unique criteria names.
 
         Returns:
             list[str]: A list of unique criteria names extracted from the recommendation expressions. The order of

--- a/tests/recommendation/utils/expression_parsing.py
+++ b/tests/recommendation/utils/expression_parsing.py
@@ -17,7 +17,7 @@ CRITERION_PATTERN = re.compile(
     r"(?!Eq\b|And\b|Or\b|Not\b|Add\b|Div\b|Sub\b)([A-Z][A-Za-z0-9_]+)([<=>]?)"
 )
 
-CRITERION_COMBINATION_PATTERN = re.compile(r"([\!\?]?)([A-Z][A-Za-z0-9_]+)([<=>]?)")
+CRITERION_COMBINATION_PATTERN = re.compile(r"([!?]?)([A-Z][A-Za-z0-9_]+)([<=>]?)")
 
 
 def criteria_combination_str_to_df(criteria_str: str) -> pd.DataFrame:


### PR DESCRIPTION
Before this change, the `_exclude` attribute in criteria classes led to inconsistent mapping between criterion objects and logic expression objects as well a few complications which arose from handling this mismatch.

This major change in pull request is separated into two commits

1. Introduce the logical criterion combinations with operator not and use it where appropriate.
   As a result of this change, the `_exclude` attribute is always `False`.

2. Remove the `_exclude` and logic for validating and inverting it.

Both commits represent consistent states in which all tests should pass.