### PR TITLE
fix: add tie-breaker in compare_events in find_rectangles

### DIFF
--- a/execution_engine/task/process/rectangle_cython.pyx
+++ b/execution_engine/task/process/rectangle_cython.pyx
@@ -379,8 +379,10 @@ def find_rectangles(
                 return (
                     -1 if (event1[1] is False) else 1
                 )  # sort close events before open events
-        else:  # at the same time, but different tracks => any order is fine
-            return 1
+        else:  # at the same time, but different tracks any order is
+            # fine as long as it is consistent so we use the track
+            # number as a tie-breaker
+            return -1 if (event1[3] < event2[3]) else 1
 
     # Sort events chronologically according to compare_events
     events.sort(key=cmp_to_key(compare_events))

--- a/execution_engine/task/process/rectangle_python.py
+++ b/execution_engine/task/process/rectangle_python.py
@@ -374,8 +374,10 @@ def find_rectangles(
                 return (
                     -1 if (event1[1] is False) else 1
                 )  # sort close events before open events
-        else:  # at the same time, but different tracks => any order is fine
-            return 1
+        else:  # at the same time, but different tracks any order is
+            # fine as long as it is consistent so we use the track
+            # number as a tie-breaker
+            return -1 if (event1[3] < event2[3]) else 1
 
     # Sort events chronologically according to compare_events
     events.sort(key=cmp_to_key(compare_events))


### PR DESCRIPTION
The local function compare_events is used to sort events and thus should induce a total order. Before this change, the final `else` clauses of the function which handled the "don't care" case as

``` python
  else:
    return 1
```

did not induce a total order since it could lead to

```
      compare_events(a, b) == 1
  and compare_events(b, a) == 1
  => a < b and b < a
```

for certain events `a`, `b`.

This change introduces a tie-breaker criterion so that either (a < b and not b < a) or the other way around.