### PR TITLE
fix: CappedMinCount not returning NOT_APPLICABLE

### DIFF
--- a/execution_engine/task/task.py
+++ b/execution_engine/task/task.py
@@ -494,6 +494,8 @@ class Task:
                 )
                 if positive_count >= effective_count_min:
                     effective_type = IntervalType.POSITIVE
+                elif not_applicable_count == len(intervals):
+                    effective_type = IntervalType.NOT_APPLICABLE
                 else:
                     effective_type = IntervalType.NEGATIVE
                 ratio = positive_count / effective_count_min


### PR DESCRIPTION
fixes the case where all inputs to CappedMinCount are NOT_APPLICABLE, which until now returned NEGATIVE, but should have been returning NOT_APPLICABLE